### PR TITLE
ack时判断成功状态以避免一个会引起崩溃的队列顺序问题

### DIFF
--- a/client/simple_canal_connector.go
+++ b/client/simple_canal_connector.go
@@ -253,7 +253,10 @@ func (c *SimpleCanalConnector) Get(batchSize int32, timeOut *int64, units *int32
 	if err != nil {
 		return nil, err
 	}
-	c.Ack(message.Id)
+	err = c.Ack(message.Id)
+	if err != nil {
+		return nil, err
+	}
 	return message, nil
 }
 


### PR DESCRIPTION
在弱网络和不稳定网络情况下，ack失败会引起panic错误 详见 https://github.com/alibaba/canal/issues/625

测试判断之后可有效避免该问题