### PR TITLE
fix:import error packege

### DIFF
--- a/client/canal_connector.go
+++ b/client/canal_connector.go
@@ -16,7 +16,6 @@
 
 package client
 
-//import pb "github.com/CanalClient/canal-go/protocol"
 import pb "github.com/withlin/canal-go/protocol"
 
 type CanalConnector interface {

--- a/client/canal_connector.go
+++ b/client/canal_connector.go
@@ -16,7 +16,8 @@
 
 package client
 
-import pb "github.com/CanalClient/canal-go/protocol"
+//import pb "github.com/CanalClient/canal-go/protocol"
+import pb "github.com/withlin/canal-go/protocol"
 
 type CanalConnector interface {
 	Connect()

--- a/client/cluster_canal_connector.go
+++ b/client/cluster_canal_connector.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	pb "github.com/CanalClient/canal-go/protocol"
+	pb "github.com/withlin/canal-go/protocol"
 )
 
 type ClusterCanalConnector struct {

--- a/client/simple_canal_connector.go
+++ b/client/simple_canal_connector.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 	"sync"
 
-	pb "github.com/CanalClient/canal-go/protocol"
+	pb "github.com/withlin/canal-go/protocol"
 
 	"github.com/golang/protobuf/proto"
 )


### PR DESCRIPTION
In client dir of canal-go
this files `simple_canal_connector.go` `canal_connector.go` `cluster_canal_connector.go` import error package `pb "github.com/CanalClient/canal-go/protocol"`
I fix it when I change `pb "github.com/CanalClient/canal-go/protocol"` to `pb "github.com/withlin/canal-go/protocol"`