### PR TITLE
增加对 ClientAuth 密码的处理 #46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 
 .vscode
 .idea
+
+vendor

--- a/client/security_util.go
+++ b/client/security_util.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+)
+
+func Scramble411(data *[]byte,seed *[]byte) []byte {
+	crypt := sha1.New()
+
+	//stage1
+	crypt.Write(*data)
+	stage1 := crypt.Sum(nil)
+
+	//stage2
+	crypt.Reset()
+	crypt.Write(stage1)
+	stage2 := crypt.Sum(nil)
+
+	//stage3
+	crypt.Reset()
+	crypt.Write(*seed)
+	crypt.Write(stage2)
+	stage3 := crypt.Sum(nil)
+	for i := range stage3 {
+		stage3[i] ^= stage1[i]
+	}
+
+	return stage3
+}
+
+func ByteSliceToHexString(data []byte) string {
+	return hex.EncodeToString(data)
+}

--- a/client/simple_canal_connector.go
+++ b/client/simple_canal_connector.go
@@ -147,11 +147,13 @@ func (c SimpleCanalConnector) doConnect() error {
 		}
 
 		handshake := &pb.Handshake{}
+		seed := &handshake.Seeds
 		err = proto.Unmarshal(p.GetBody(), handshake)
 		if err != nil {
 			return err
 		}
-		pas := []byte(c.PassWord)
+		bytePas :=[]byte(c.PassWord)
+		pas := []byte(ByteSliceToHexString(Scramble411(&bytePas,seed)))
 		ca := &pb.ClientAuth{
 			Username:               c.UserName,
 			Password:               pas,


### PR DESCRIPTION
Fixes[issue#46](https://github.com/withlin/canal-go/issues/46)
测试截图：
![image](https://user-images.githubusercontent.com/13200155/98202195-74b6d400-1f6c-11eb-93f8-7dc6e673e6b4.png)


注意：配置文件配的密码是密文，而代码中需要传入的是明文