### PR TITLE
连接中再次创建临时节点时将zk版本设置为0

### DIFF
--- a/client/cluster_canal_connector.go
+++ b/client/cluster_canal_connector.go
@@ -3,11 +3,12 @@ package client
 import (
 	"errors"
 	"fmt"
-	"github.com/go-zookeeper/zk"
 	"log"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/go-zookeeper/zk"
 
 	pb "github.com/withlin/canal-go/protocol"
 )
@@ -284,6 +285,8 @@ func (cc *ClusterCanalConnector) waitBecomeFirst() error {
 			if err != nil {
 				return err
 			}
+			// 再次创建临时节点成功后将版本设置为0，不然后续更新节点会出现版本冲突
+			cc.zkVersion = 0
 			return cc.waitBecomeFirst()
 		}
 	}


### PR DESCRIPTION
client连接中再次创建临时节点时没有将zk版本设置为0；导致后面成为首个节点后再次更新节点会出现版本冲突问题